### PR TITLE
fix: strict peerDependencies fails about not resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,7 @@ jobs:
           npm install
 
       - name: Install PeerDeps
-        run: |
-          npm i fastify/fastify#next
-          npm i @sinclair/typebox
+        run: npm i fastify @sinclair/typebox
 
       - name: Run tests
         run: |

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "peerDependencies": {
     "@sinclair/typebox": "^0.23.0",
-    "fastify": "github:fastify/fastify#next"
+    "fastify": "^4.0.0"
   },
   "scripts": {
     "build": "rimraf ./dist && mkdir dist && tsc --outDir dist",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [-] tests and/or benchmarks are included
- [-] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

When using `pnpm` 7.0.0 introduced strictPeerDependencies that means that all peerDependencies must be resolved to `pnpm install` finish, something kinda similar happens on `npm` and `yarn 2`

Since 4.0.0 it's already been released, pointing next is not a good decision, because it fails when installing and using fastify: 4.0.0@rc or 4.0.0@latest (which are perfectly valid)



