### PR TITLE
Fixes #19 Remove Explicit Kind and Modifier Configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12, 14, 16, 17]
+        node-version: [14, 16, 17, 18]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -17,19 +17,6 @@ import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 ```
 
-**Note**: For [ajv] version 7 and above is required to use the `ajvTypeBoxPlugin`:
-
-```ts
-import Fastify from 'fastify'
-import { ajvTypeBoxPlugin, TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
-
-const fastify = Fastify({
-  ajv: {
-    plugins: [ajvTypeBoxPlugin]
-  }
-}).withTypeProvider<TypeBoxTypeProvider>()
-```
-
 ## Example
 
 ```ts

--- a/index.ts
+++ b/index.ts
@@ -5,8 +5,3 @@ import { Static, TSchema } from '@sinclair/typebox'
 export interface TypeBoxTypeProvider extends FastifyTypeProvider {
   output: this['input'] extends TSchema ? Static<this['input']> : never
 }
-
-export const ajvTypeBoxPlugin = function (ajv: any): void {
-  ajv.addKeyword({ keyword: 'kind' })
-  ajv.addKeyword({ keyword: 'modifier' })
-}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "peerDependencies": {
-    "@sinclair/typebox": "^0.23.0",
+    "@sinclair/typebox": "^0.24.1",
     "fastify": "^4.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "rimraf ./dist && mkdir dist && tsc --outDir dist",
-    "test": "npm run build && npm run typescript",
+    "test": "npm run build && npm run typescript && tap tests/index.js",
     "typescript": "tsd"
   },
   "repository": {
@@ -29,8 +29,10 @@
   "homepage": "https://github.com/fastify/fastify-type-provider-typebox#readme",
   "devDependencies": {
     "@types/node": "^18.0.0",
+    "fastify": "^4.2.0",
     "fastify-tsconfig": "^1.0.1",
     "rimraf": "^3.0.2",
+    "tap": "^16.3.0",
     "tsd": "^0.21.0"
   },
   "tsd": {

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,7 +15,7 @@ tap.test('should compile typebox schema without configuration', async t => {
         }
     }, (_req, _res) => { })
     await fastify.listen({ port: 5000 })
-    fastify.close()
+    await fastify.close()
     t.pass()
 })
 
@@ -34,7 +34,7 @@ tap.test('should not compile schema with unknown keywords', async t => {
     try {
         await fastify.listen({ port: 5000 }) // expect throw
     } catch {
-        fastify.close()
+        await fastify.close()
         t.pass()
     }
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -33,6 +33,7 @@ tap.test('should not compile schema with unknown keywords', async t => {
     }, (_req, _res) => { })
     try {
         await fastify.listen({ port: 5000 }) // expect throw
+        t.fail()
     } catch {
         await fastify.close()
         t.pass()

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,40 @@
+const tap = require('tap')
+const Fastify = require('fastify')
+const { Type } = require('@sinclair/typebox')
+
+// Tests that Fastify accepts TypeBox schemas without explicit configuration
+tap.test('should compile typebox schema without configuration', async t => {
+    t.plan(1)
+    const fastify = Fastify().get('/', {
+        schema: {
+            querystring: Type.Object({
+                x: Type.Number(),
+                y: Type.Number(),
+                z: Type.Number()
+            })
+        }
+    }, (_req, _res) => { })
+    await fastify.listen({ port: 5000 })
+    fastify.close()
+    t.pass()
+})
+
+// Tests that Fastify rejects unknown properties on the schema.
+tap.test('should not compile schema with unknown keywords', async t => {
+    t.plan(1)
+    const fastify = Fastify().get('/', {
+        schema: {
+            querystring: Type.Object({
+                x: Type.Number(),
+                y: Type.Number(),
+                z: Type.Number()
+            }, { kind: 'Object' }) // unknown
+        }
+    }, (_req, _res) => { })
+    try {
+        await fastify.listen({ port: 5000 }) // expect throw
+    } catch {
+        fastify.close()
+        t.pass()
+    }
+})

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { TypeBoxTypeProvider, ajvTypeBoxPlugin } from '../index'
+import { TypeBoxTypeProvider } from '../index'
 import { Type } from '@sinclair/typebox'
 import { expectAssignable, expectType } from 'tsd'
 import Fastify, { FastifyInstance, FastifyLoggerInstance, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerDefault } from 'fastify'
@@ -11,7 +11,7 @@ fastify.get('/', {
     body: Type.Object({
       x: Type.String(),
       y: Type.Number(),
-      z: Type.Boolean()
+      z: Type.Boolean(),
     })
   }
 }, (req) => {
@@ -20,5 +20,4 @@ fastify.get('/', {
   expectType<string>(req.body.x)
 })
 
-expectAssignable<FastifyInstance>(Fastify({ ajv: { plugins: [ajvTypeBoxPlugin] } }))
-expectType<void>(ajvTypeBoxPlugin({ addKeyword: () => {} }))
+expectAssignable<FastifyInstance>(Fastify())


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR removes the `ajvTypeBoxPlugin` that was previously required to configure AJV for the TypeBox `kind` and `modifier` keywords. As of TypeBox `0.24.0`, these properties have been changed to `symbol` keys which are permissible by AJV in `strict` mode without explicit configuration.

Updates:
- Remove `ajvTypeBoxPlugin` export from `index.ts`
- Updated `peerDependency` to `@sinclair/typebox/0.24.0`
- Updated readme documentation (omit section for AJV 7)
- Updated tests. Removed `ajvTypeBoxPlugin` checks.

Submitting for review