### PR TITLE
Feature: TypeBoxValidatorCompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,28 @@ export const CreateProductHandler = (
   const { name, price } = req.body;
 };
 ```
+## Type Compiler
+
+TypeBox provides an optional type compiler that perform very fast runtime type checking for data received on routes. Note this compiler is limited to types expressable through the TypeBox `Type.*` namespace only. To enable this compiler, you can call `.setValidatorCompiler(...)` with the `TypeBoxValidatorCompiler` export provided by this package.
+
+```ts
+import { TypeBoxTypeProvider, TypeBoxValidatorCompiler } from '@fastify/type-provider-typebox'
+import { Type } from '@sinclair/typebox'
+import Fastify from 'fastify'
+
+const fastify = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler)
+
+fastify.withTypeProvider<TypeBoxTypeProvider>().get('/', {
+  schema: {
+    querystring: Type.Object({
+      x: Type.String(),
+      y: Type.Number(),
+      z: Type.Boolean()
+    })
+  }
+}, (req) => {
+  const { x, y, z } = req.query
+})
+```
+
+For additional information on this compiler, please refer to the TypeBox documentation located [here](https://github.com/sinclairzx81/typebox#Compiler)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export const CreateProductHandler = (
   const { name, price } = req.body;
 };
 ```
+
 ## Type Compiler
 
 TypeBox provides an optional type compiler that perform very fast runtime type checking for data received on routes. Note this compiler is limited to types expressable through the TypeBox `Type.*` namespace only. To enable this compiler, you can call `.setValidatorCompiler(...)` with the `TypeBoxValidatorCompiler` export provided by this package.

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ fastify.withTypeProvider<TypeBoxTypeProvider>().get('/', {
   schema: {
     querystring: Type.Object({
       x: Type.String(),
-      y: Type.Number(),
-      z: Type.Boolean()
+      y: Type.String(),
+      z: Type.String()
     })
   }
 }, (req) => {

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,44 @@
-import { FastifyTypeProvider } from 'fastify'
-
+import { FastifySchemaCompiler, FastifyTypeProvider } from "fastify"
+import { TypeCompiler, ValueError } from '@sinclair/typebox/compiler'
 import { Static, TSchema } from '@sinclair/typebox'
 
+export class TypeBoxValidationError extends Error {
+  constructor(public readonly errors: ValueError[]) {
+      super('[' + errors.map(({ path, message }) => `['${path}', '${message}']`).join(', ') + ']')
+  }
+}
+
+/** 
+ * Enables TypeBox schema validation
+ * 
+ * @example
+ * ```typescript
+ * import Fastify from 'fastify'
+ * 
+ * const server = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler) 
+ * ```
+ */
+ export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schema }) => {
+  const typeCheck = TypeCompiler.Compile(schema)
+  return (value): any => {
+      if (typeCheck.Check(value)) return
+      // Future: Consider returning FastifySchemaValidationError[] structure instead of throw. The TypeBoxValidationError 
+      // does generates human readable (and parsable) error messages, however the FastifySchemaValidationError may be a
+      // better fit as it would allow Fastify to standardize on error reporting. For consideration.
+      throw new TypeBoxValidationError([...typeCheck.Errors(value)])
+  }
+}
+
+/** 
+ * Enables automatic type inference on a Fastify instance.
+ * 
+ * @example
+ * ```typescript
+ * import Fastify from 'fastify'
+ * 
+ * const server = Fastify().withTypeProvider<TypeBoxTypeProvider>()
+ * ```
+ */
 export interface TypeBoxTypeProvider extends FastifyTypeProvider {
   output: this['input'] extends TSchema ? Static<this['input']> : never
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^18.0.0",
     "fastify": "^4.2.0",
     "fastify-tsconfig": "^1.0.1",
-    "node-fetch": "^3.2.6",
+    "node-fetch": "^2.6.7",
     "rimraf": "^3.0.2",
     "tap": "^16.3.0",
     "tsd": "^0.22.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/node": "^18.0.0",
     "fastify": "^4.2.0",
     "fastify-tsconfig": "^1.0.1",
-    "node-fetch": "^2.6.7",
     "rimraf": "^3.0.2",
     "tap": "^16.3.0",
     "tsd": "^0.22.0"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/node": "^18.0.0",
     "fastify": "^4.2.0",
     "fastify-tsconfig": "^1.0.1",
+    "node-fetch": "^3.2.6",
     "rimraf": "^3.0.2",
     "tap": "^16.3.0",
     "tsd": "^0.22.0"

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,7 +2,6 @@ const tap = require('tap')
 const Fastify = require('fastify')
 const { Type } = require('@sinclair/typebox')
 const { TypeBoxValidatorCompiler } = require('../dist/index')
-const fetch = require('node-fetch')
 
 // This test ensures AJV ignores the TypeBox [Kind] symbol property in strict
 tap.test('should compile typebox schema without configuration', async t => {
@@ -54,9 +53,9 @@ tap.test('should validate querystring parameters', async t => {
         }
     }, (req, res) => res.send(req.query))
     await fastify.listen({ port: 5000 })
-    const { a, b, c } = await fetch('http://localhost:5000/?a=1&b=2&c=3').then(res => res.json())
+    const { a, b, c } = await fastify.inject().get('/').query({ a: '1', b: '2', c: '3' }).then(res => res.json())
     await fastify.close()
-    if(a === '1' && b === '2' & c === '3') {
+    if (a === '1' && b === '2' & c === '3') {
         t.pass()
     } else {
         t.fail()
@@ -74,12 +73,13 @@ tap.test('should not validate querystring parameters', async t => {
             })
         }
     }, (req, res) => res.send(req.query))
+
     await fastify.listen({ port: 5000 })
-    const status = await fetch('http://localhost:5000/?a=1&b=2').then(res => res.status)
+    const statusCode = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.statusCode)
     await fastify.close()
-    if(status !== 500) {
-        t.fail()
-    } else {
+    if (statusCode === 500) {
         t.pass()
+    } else {
+        t.fail()
     }
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -52,9 +52,7 @@ tap.test('should validate querystring parameters', async t => {
             })
         }
     }, (req, res) => res.send(req.query))
-    await fastify.listen({ port: 5000 })
     const { a, b, c } = await fastify.inject().get('/').query({ a: '1', b: '2', c: '3' }).then(res => res.json())
-    await fastify.close()
     if (a === '1' && b === '2' & c === '3') {
         t.pass()
     } else {
@@ -73,13 +71,6 @@ tap.test('should not validate querystring parameters', async t => {
             })
         }
     }, (req, res) => res.send(req.query))
-
-    await fastify.listen({ port: 5000 })
     const statusCode = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.statusCode)
-    await fastify.close()
-    if (statusCode === 500) {
-        t.pass()
-    } else {
-        t.fail()
-    }
+    t.equal(statusCode, 500)
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,8 +15,7 @@ tap.test('should compile typebox schema without configuration', async t => {
             })
         }
     }, (_req, _res) => { })
-    await fastify.listen({ port: 5000 })
-    await fastify.close()
+    await fastify.ready()
     t.pass()
 })
 
@@ -33,10 +32,9 @@ tap.test('should not compile schema with unknown keywords', async t => {
         }
     }, (_req, _res) => { })
     try {
-        await fastify.listen({ port: 5000 }) // expect throw
+        await fastify.ready() // expect throw
         t.fail()
     } catch {
-        await fastify.close()
         t.pass()
     }
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -55,12 +55,12 @@ tap.test('should validate querystring parameters', async t => {
     }, (req, res) => res.send(req.query))
     await fastify.listen({ port: 5000 })
     const { a, b, c } = await fetch('http://localhost:5000/?a=1&b=2&c=3').then(res => res.json())
+    await fastify.close()
     if(a === '1' && b === '2' & c === '3') {
         t.pass()
     } else {
         t.fail()
     }
-    await fastify.close()
 })
 
 tap.test('should not validate querystring parameters', async t => {
@@ -76,10 +76,10 @@ tap.test('should not validate querystring parameters', async t => {
     }, (req, res) => res.send(req.query))
     await fastify.listen({ port: 5000 })
     const status = await fetch('http://localhost:5000/?a=1&b=2').then(res => res.status)
+    await fastify.close()
     if(status !== 500) {
         t.fail()
     } else {
         t.pass()
     }
-    await fastify.close()
 })


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR implements the TypeBox TypeCompiler mentioned on issue https://github.com/fastify/fastify-type-provider-typebox/issues/23. This compiler can used to attain faster runtime validation performance (roughly 1.5x the performance of AJV), as well as significantly increase schema compilation time. Note this compiler only accepts TypeBox types for compilation, and thus should be considered optional from a users standpoint.

Documentation on the Compiler and associated Benchmarks can be located on the TypeBox repository located [here](https://github.com/sinclairzx81/typebox#compiler). Current benchmarks listed below.

#### Validate

This benchmark measures overall validate performance. You can review this benchmark [here](https://github.com/sinclairzx81/typebox/blob/master/benchmark/check.ts).

```typescript
┌──────────────────┬────────────┬────────────┬────────────┬────────────────────────┐
│     (index)      │ Iterations │    Ajv     │  TypeBox   │        Measured        │
├──────────────────┼────────────┼────────────┼────────────┼────────────────────────┤
│           Number │  16000000  │ '74ms    ' │ '66ms    ' │ '1.12 x faster       ' │
│           String │  16000000  │ '277ms   ' │ '154ms   ' │ '1.80 x faster       ' │
│          Boolean │  16000000  │ '263ms   ' │ '152ms   ' │ '1.73 x faster       ' │
│             Null │  16000000  │ '275ms   ' │ '153ms   ' │ '1.80 x faster       ' │
│            RegEx │  16000000  │ '658ms   ' │ '548ms   ' │ '1.20 x faster       ' │
│          ObjectA │  16000000  │ '453ms   ' │ '319ms   ' │ '1.42 x faster       ' │
│          ObjectB │  16000000  │ '676ms   ' │ '514ms   ' │ '1.32 x faster       ' │
│            Tuple │  16000000  │ '320ms   ' │ '193ms   ' │ '1.66 x faster       ' │
│            Union │  16000000  │ '331ms   ' │ '211ms   ' │ '1.57 x faster       ' │
│        Recursive │  16000000  │ '6010ms  ' │ '2368ms  ' │ '2.54 x faster       ' │
│          Vector4 │  16000000  │ '313ms   ' │ '168ms   ' │ '1.86 x faster       ' │
│          Matrix4 │  16000000  │ '604ms   ' │ '419ms   ' │ '1.44 x faster       ' │
│   Literal_String │  16000000  │ '281ms   ' │ '154ms   ' │ '1.82 x faster       ' │
│   Literal_Number │  16000000  │ '268ms   ' │ '150ms   ' │ '1.79 x faster       ' │
│  Literal_Boolean │  16000000  │ '273ms   ' │ '149ms   ' │ '1.83 x faster       ' │
│     Array_Number │  16000000  │ '470ms   ' │ '235ms   ' │ '2.00 x faster       ' │
│     Array_String │  16000000  │ '462ms   ' │ '303ms   ' │ '1.52 x faster       ' │
│    Array_Boolean │  16000000  │ '527ms   ' │ '352ms   ' │ '1.50 x faster       ' │
│    Array_ObjectA │  16000000  │ '43852ms ' │ '28042ms ' │ '1.56 x faster       ' │
│    Array_ObjectB │  16000000  │ '48025ms ' │ '33205ms ' │ '1.45 x faster       ' │
│      Array_Tuple │  16000000  │ '1424ms  ' │ '1095ms  ' │ '1.30 x faster       ' │
│    Array_Vector4 │  16000000  │ '1495ms  ' │ '808ms   ' │ '1.85 x faster       ' │
│    Array_Matrix4 │  16000000  │ '6129ms  ' │ '4969ms  ' │ '1.23 x faster       ' │
└──────────────────┴────────────┴────────────┴────────────┴────────────────────────┘
```

#### Compile

This benchmark measures schema compilation time. You can review this benchmark [here](https://github.com/sinclairzx81/typebox/blob/master/benchmark/compile.ts).

```typescript
┌──────────────────┬────────────┬────────────┬────────────┬────────────────────────┐
│     (index)      │ Iterations │    Ajv     │  TypeBox   │        Measured        │
├──────────────────┼────────────┼────────────┼────────────┼────────────────────────┤
│           Number │    2000    │ '400ms   ' │ '8ms     ' │ '50.00 x faster      ' │
│           String │    2000    │ '324ms   ' │ '7ms     ' │ '46.29 x faster      ' │
│          Boolean │    2000    │ '325ms   ' │ '10ms    ' │ '32.50 x faster      ' │
│             Null │    2000    │ '271ms   ' │ '4ms     ' │ '67.75 x faster      ' │
│            RegEx │    2000    │ '493ms   ' │ '11ms    ' │ '44.82 x faster      ' │
│          ObjectA │    2000    │ '2998ms  ' │ '27ms    ' │ '111.04 x faster     ' │
│          ObjectB │    2000    │ '3058ms  ' │ '28ms    ' │ '109.21 x faster     ' │
│            Tuple │    2000    │ '1306ms  ' │ '19ms    ' │ '68.74 x faster      ' │
│            Union │    2000    │ '1450ms  ' │ '18ms    ' │ '80.56 x faster      ' │
│          Vector4 │    2000    │ '1633ms  ' │ '12ms    ' │ '136.08 x faster     ' │
│          Matrix4 │    2000    │ '984ms   ' │ '10ms    ' │ '98.40 x faster      ' │
│   Literal_String │    2000    │ '376ms   ' │ '5ms     ' │ '75.20 x faster      ' │
│   Literal_Number │    2000    │ '396ms   ' │ '7ms     ' │ '56.57 x faster      ' │
│  Literal_Boolean │    2000    │ '383ms   ' │ '3ms     ' │ '127.67 x faster     ' │
│     Array_Number │    2000    │ '748ms   ' │ '6ms     ' │ '124.67 x faster     ' │
│     Array_String │    2000    │ '774ms   ' │ '5ms     ' │ '154.80 x faster     ' │
│    Array_Boolean │    2000    │ '814ms   ' │ '8ms     ' │ '101.75 x faster     ' │
│    Array_ObjectA │    2000    │ '3675ms  ' │ '24ms    ' │ '153.13 x faster     ' │
│    Array_ObjectB │    2000    │ '4364ms  ' │ '30ms    ' │ '145.47 x faster     ' │
│      Array_Tuple │    2000    │ '2236ms  ' │ '13ms    ' │ '172.00 x faster     ' │
│    Array_Vector4 │    2000    │ '1772ms  ' │ '15ms    ' │ '118.13 x faster     ' │
│    Array_Matrix4 │    2000    │ '1612ms  ' │ '10ms    ' │ '161.20 x faster     ' │
└──────────────────┴────────────┴────────────┴────────────┴────────────────────────┘
```
#### Additional Updates

- Updated type documentation and include JSDoc `@example` for `TypeBoxTypeProvider` and `TypeBoxValidatorCompiler` respectively. (Useful for vscode intellisense)
- Implemented tests

#### Not implemented

- Re-export TypeBox `Type` and and associated types on this provider (note: re-exporting TypeBox currently causes coverage tests to fall below threshold)

Submitting for review