### PR TITLE
feat: add typebox plugin types

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ export const CreateProductHandler = (
 };
 ```
 
+
+## Plugin definition
+
+> **Note**
+> When using plugin types, withTypeProvider is not required in order to register the plugin
+
+```ts
+import { Type } from '@sinclair/typebox';
+import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
+
+const plugin: FastifyPluginAsyncTypebox = async function(fastify, _opts) {
+  fastify.get('/', {
+    schema: {
+      body: Type.Object({
+        x: Type.String(),
+        y: Type.Number(),
+        z: Type.Boolean()
+      })
+    }
+  }, (req) => {
+    /// The `x`, `y`, and `z` types are automatically inferred
+    const { x, y, z } = req.body
+  });
+}
+```
+
 ## Type Compiler
 
 TypeBox provides an optional type compiler that perform very fast runtime type checking for data received on routes. Note this compiler is limited to types expressable through the TypeBox `Type.*` namespace only. To enable this compiler, you can call `.setValidatorCompiler(...)` with the `TypeBoxValidatorCompiler` export provided by this package.

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,12 @@
-import { FastifySchemaCompiler, FastifyTypeProvider } from "fastify"
+import {
+  FastifyPluginAsync,
+  FastifyPluginCallback,
+  FastifyPluginOptions,
+  FastifySchemaCompiler,
+  FastifyTypeProvider,
+  RawServerBase,
+  RawServerDefault
+} from "fastify"
 import { TypeCompiler, ValueError } from '@sinclair/typebox/compiler'
 import { Static, TSchema } from '@sinclair/typebox'
 
@@ -42,3 +50,39 @@ export class TypeBoxValidationError extends Error {
 export interface TypeBoxTypeProvider extends FastifyTypeProvider {
   output: this['input'] extends TSchema ? Static<this['input']> : never
 }
+
+
+
+/**
+ * FastifyPluginCallback with Typebox automatic type inference
+ * 
+ * @example
+ * ```typescript
+ * import { FastifyPluginCallbackTypebox } fromg "@fastify/type-provider-typebox"
+ * 
+ * const plugin: FastifyPluginCallbackTypebox = (fastify, options, done) => {
+ *   done()
+ * }
+ * ```
+ */
+export type FastifyPluginCallbackTypebox<
+    Options extends FastifyPluginOptions = Record<never, never>,
+    Server extends RawServerBase = RawServerDefault,
+> = FastifyPluginCallback<Options, Server, TypeBoxTypeProvider>
+
+
+/**
+ * FastifyPluginAsync with Typebox automatic type inference
+ * 
+ * @example
+ * ```typescript
+ * import { FastifyPluginAsyncTypebox } fromg "@fastify/type-provider-typebox"
+ * 
+ * const plugin: FastifyPluginAsyncTypebox = async (fastify, options) => {
+ * }
+ * ```
+ */
+export type FastifyPluginAsyncTypebox<
+  Options extends FastifyPluginOptions = Record<never, never>,
+  Server extends RawServerBase = RawServerDefault
+> = FastifyPluginAsync<Options, Server, TypeBoxTypeProvider>

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,0 +1,78 @@
+import { FastifyPluginAsyncTypebox, FastifyPluginCallbackTypebox } from '../index'
+import { expectType } from 'tsd'
+import Fastify, { FastifyPluginAsync, FastifyPluginCallback } from 'fastify'
+import { Type } from '@sinclair/typebox'
+import { Http2Server } from 'http2'
+
+
+// Ensure the defaults of FastifyPluginAsyncTypebox are the same as FastifyPluginAsync
+export const pluginAsyncDefaults: FastifyPluginAsync = async (fastify, options) => {
+    const pluginAsyncTypeboxDefaults: FastifyPluginAsyncTypebox = async (fastifyWithTypebox, optionsTypebox) => {
+        expectType<typeof fastifyWithTypebox['server']>(fastify.server);
+        expectType<typeof optionsTypebox>(options);
+    }
+    fastify.register(pluginAsyncTypeboxDefaults)
+
+}
+
+
+// Ensure the defaults of FastifyPluginCallbackTypebox are the same as FastifyPluginCallback
+export const pluginCallbackDefaults: FastifyPluginCallback = async (fastify, options, done) => {
+    const pluginCallbackTypeboxDefaults: FastifyPluginCallbackTypebox = async (fastifyWithTypebox, optionsTypebox, doneTypebox) => {
+        expectType<typeof fastifyWithTypebox['server']>(fastify.server);
+        expectType<typeof optionsTypebox>(options);
+    }
+
+    fastify.register(pluginCallbackTypeboxDefaults)
+}
+
+
+const asyncPlugin: FastifyPluginAsyncTypebox<{ optionA: string }, Http2Server> = async (fastify, options) => {
+    
+    expectType<Http2Server>(fastify.server)
+    
+    expectType<string>(options.optionA)
+
+    fastify.get('/', {
+        schema: {
+            body: Type.Object({
+                x: Type.String(),
+                y: Type.Number(),
+                z: Type.Boolean(),
+            })
+        }
+    }, (req) => {
+        expectType<boolean>(req.body.z)
+        expectType<number>(req.body.y)
+        expectType<string>(req.body.x)
+    })
+}
+
+
+const callbackPlugin: FastifyPluginCallbackTypebox<{ optionA: string }, Http2Server> = (fastify, options, done) => {
+    
+    expectType<Http2Server>(fastify.server)
+
+    expectType<string>(options.optionA)
+
+    fastify.get('/', {
+        schema: {
+            body: Type.Object({
+                x: Type.String(),
+                y: Type.Number(),
+                z: Type.Boolean(),
+            })
+        }
+    }, (req) => {
+        expectType<boolean>(req.body.z)
+        expectType<number>(req.body.y)
+        expectType<string>(req.body.x)
+    })
+    done()
+}
+
+
+const fastify = Fastify()
+
+fastify.register(asyncPlugin)
+fastify.register(callbackPlugin)


### PR DESCRIPTION
Add plugin specific types

- `FastifyPluginCallbackTypebox`
- `FastifyPluginAsyncTypebox`


Discussed [here](https://github.com/fastify/fastify/issues/3636)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
