### PR TITLE
Fix #26 Validation Error Response

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,14 +7,8 @@ import {
   RawServerBase,
   RawServerDefault
 } from "fastify"
-import { TypeCompiler, ValueError } from '@sinclair/typebox/compiler'
+import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Static, TSchema } from '@sinclair/typebox'
-
-export class TypeBoxValidationError extends Error {
-  constructor(public readonly errors: ValueError[]) {
-      super('[' + errors.map(({ path, message }) => `['${path}', '${message}']`).join(', ') + ']')
-  }
-}
 
 /** 
  * Enables TypeBox schema validation

--- a/index.ts
+++ b/index.ts
@@ -29,11 +29,18 @@ export class TypeBoxValidationError extends Error {
  export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schema }) => {
   const typeCheck = TypeCompiler.Compile(schema)
   return (value): any => {
-      if (typeCheck.Check(value)) return
-      // Future: Consider returning FastifySchemaValidationError[] structure instead of throw. The TypeBoxValidationError 
-      // does generates human readable (and parsable) error messages, however the FastifySchemaValidationError may be a
-      // better fit as it would allow Fastify to standardize on error reporting. For consideration.
-      throw new TypeBoxValidationError([...typeCheck.Errors(value)])
+    if (typeCheck.Check(value)) return
+    const errors = [...typeCheck.Errors(value)]
+    return {
+      // Note: Here we return a FastifySchemaValidationError[] result. As of writing, Fastify
+      // does not currently export this type. Future revisions should uncomment the assertion 
+      // below and return the full set of properties. The specified properties 'message' and
+      // 'instancePath' do however result in a near equivalent error messages to Ajv. 
+      error: errors.map((error) => ({
+        message: `${error.message}`,
+        instancePath: error.path
+      })) // as FastifySchemaValidationError[] 
+    } 
   }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -70,5 +70,20 @@ tap.test('should not validate querystring parameters', async t => {
     }
   }, (req, res) => res.send(req.query))
   const statusCode = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.statusCode)
-  t.equal(statusCode, 500)
+  t.equal(statusCode, 400)
+})
+
+tap.test('should return validation error message on response', async t => {
+  t.plan(1)
+  const fastify = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler).get('/', {
+    schema: {
+      querystring: Type.Object({
+        a: Type.String(),
+        b: Type.String(),
+        c: Type.String()
+      })
+    }
+  }, (req, res) => res.send(req.query))
+  const response = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.json())
+  t.equal(response.message.indexOf('querystring/c'), 0)
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -70,5 +70,20 @@ tap.test('should not validate querystring parameters', async t => {
         }
     }, (req, res) => res.send(req.query))
     const statusCode = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.statusCode)
-    t.equal(statusCode, 500)
+    t.equal(statusCode, 400)
+})
+
+tap.test('should return validation error message on response', async t => {
+    t.plan(1)
+    const fastify = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler).get('/', {
+        schema: {
+            querystring: Type.Object({
+                a: Type.String(),
+                b: Type.String(),
+                c: Type.String()
+            })
+        }
+    }, (req, res) => res.send(req.query))
+    const response = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.json())
+    t.equal(response.message.indexOf('querystring/c'), 0)
 })


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR updates the `TypeBoxValidatorCompiler` to return values of `FastifySchemaValidationError` on validation fail. This to prevent Fastify from crashing due to throwing an exception within the compiler validate callback. As of this PR, invalid data passed to the route will now result in a correct `400: Bad Request` and an appropriate error object is returned on the response with a message hinting at what data is incorrect.

### Note

I note that Fastify currently doesn't appear to directly export the `FastifyValidationResult` and `FastifySchemaValidationError` types. These types are accessible by importing  `fastify/types/schema` however. I have left a comment here to potentially update the implementation with a TS assertion on the error result (for correctness), however the current error result seems to generate adequate errors with the properties specified.

Submitting for community review

