### PR TITLE
chore: add failing test for `register` calls

### DIFF
--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -42,6 +42,22 @@ const asyncPlugin: FastifyPluginAsyncTypebox<{ optionA: string }, Http2Server> =
     expectType<number>(req.body.y)
     expectType<string>(req.body.x)
   })
+
+  fastify.register(async instance => {
+    instance.get('/', {
+      schema: {
+        body: Type.Object({
+          x: Type.String(),
+          y: Type.Number(),
+          z: Type.Boolean()
+        })
+      }
+    }, (req) => {
+      expectType<boolean>(req.body.z)
+      expectType<number>(req.body.y)
+      expectType<string>(req.body.x)
+    })
+  })
 }
 
 const callbackPlugin: FastifyPluginCallbackTypebox<{ optionA: string }, Http2Server> = (fastify, options, done) => {
@@ -62,6 +78,25 @@ const callbackPlugin: FastifyPluginCallbackTypebox<{ optionA: string }, Http2Ser
     expectType<number>(req.body.y)
     expectType<string>(req.body.x)
   })
+
+  fastify.register((instance, _, done) => {
+    instance.get('/', {
+      schema: {
+        body: Type.Object({
+          x: Type.String(),
+          y: Type.Number(),
+          z: Type.Boolean()
+        })
+      }
+    }, (req) => {
+      expectType<boolean>(req.body.z)
+      expectType<number>(req.body.y)
+      expectType<string>(req.body.x)
+    })
+
+    done()
+  })
+
   done()
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Similar to #33, this is just a failing test.

I think it would make sense for `register` to keep the `TypeProvider` provided by its parent by default - currently we have to call `withTypeProvider` on `instance` to make it pass.

This is probably an issue in https://github.com/fastify/fastify rather than in this repo, but still 🙂 

/cc @sinclairzx81 