### PR TITLE
Export Type.* Namespace on Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A Type Provider for [Typebox](https://github.com/sinclairzx81/typebox)
 
 ## Overview
 
-This package is the Type Provider for the `@sinclair/typebox` runtime type library. It enables Fastify to automatically infer `Request` and `Reply` types for schemas specified as TypeBox types.
-
-This provider re-exports a specialized `Type` builder from TypeBox which offers some additional extension types specific to Fastify. It also provides optional support for the TypeBox validation compiler.
+This package is the Type Provider for the `@sinclair/typebox` runtime type library. It enables Fastify to automatically infer `Request` and `Reply` types for schemas specified as TypeBox types. This provider exports a custom `Type` builder from TypeBox which includes some extension types specific to Fastify and provides optional support for the TypeBox validation compiler.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Type Provider for [Typebox](https://github.com/sinclairzx81/typebox)
 
+## Overview
+
+This package is the Type Provider for the `@sinclair/typebox` runtime type library. It enables Fastify to automatically infer `Request` and `Reply` types for schemas specified as TypeBox types.
+
+This provider re-exports a specialized `Type` builder from TypeBox which offers some additional extension types specific to Fastify. It also provides optional support for the TypeBox validation compiler.
+
 ## Installation
 
 ```sh
@@ -21,8 +27,7 @@ const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 
 ```ts
 import Fastify from 'fastify'
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
-import { Type } from '@sinclair/typebox'
+import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
 
 const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 
@@ -48,15 +53,15 @@ import {
   RawRequestDefaultExpression,
   RawServerDefault,
 } from 'fastify';
-import { Type } from '@sinclair/typebox';
-import { RouteGenericInterface } from 'fastify/types/route';
-import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
-export type FastifyRequestTypebox<TSchema> = FastifyRequest<
+import { RouteGenericInterface } from 'fastify/types/route';
+import { Type, TSchema, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+
+export type FastifyRequestTypebox<Schema extends TSchema> = FastifyRequest<
   RouteGenericInterface,
   RawServerDefault,
   RawRequestDefaultExpression<RawServerDefault>,
-  TSchema,
+  Schema,
   TypeBoxTypeProvider
 >;
 
@@ -82,8 +87,7 @@ export const CreateProductHandler = (
 > When using plugin types, withTypeProvider is not required in order to register the plugin
 
 ```ts
-import { Type } from '@sinclair/typebox';
-import { FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
+import { Type, FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 
 const plugin: FastifyPluginAsyncTypebox = async function(fastify, _opts) {
   fastify.get('/', {
@@ -106,8 +110,7 @@ const plugin: FastifyPluginAsyncTypebox = async function(fastify, _opts) {
 TypeBox provides an optional type compiler that perform very fast runtime type checking for data received on routes. Note this compiler is limited to types expressable through the TypeBox `Type.*` namespace only. To enable this compiler, you can call `.setValidatorCompiler(...)` with the `TypeBoxValidatorCompiler` export provided by this package.
 
 ```ts
-import { TypeBoxTypeProvider, TypeBoxValidatorCompiler } from '@fastify/type-provider-typebox'
-import { Type } from '@sinclair/typebox'
+import { Type, TypeBoxTypeProvider, TypeBoxValidatorCompiler } from '@fastify/type-provider-typebox'
 import Fastify from 'fastify'
 
 const fastify = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ import {
 } from 'fastify';
 
 import { RouteGenericInterface } from 'fastify/types/route';
-import { Type, TSchema, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
 export type FastifyRequestTypebox<Schema extends FastifySchema> = FastifyRequest<
   RouteGenericInterface,

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ import {
   FastifyRequest,
   RawRequestDefaultExpression,
   RawServerDefault,
+  FastifySchema
 } from 'fastify';
 
 import { RouteGenericInterface } from 'fastify/types/route';
 import { Type, TSchema, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
-export type FastifyRequestTypebox<Schema extends TSchema> = FastifyRequest<
+export type FastifyRequestTypebox<Schema extends FastifySchema> = FastifyRequest<
   RouteGenericInterface,
   RawServerDefault,
   RawRequestDefaultExpression<RawServerDefault>,

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   FastifyPluginAsync,
   FastifyPluginCallback,
   FastifyPluginOptions,
@@ -7,19 +7,43 @@ import {
   RawServerBase,
   RawServerDefault
 } from 'fastify'
-import { TypeCompiler } from '@sinclair/typebox/compiler'
-import { Static, TSchema } from '@sinclair/typebox'
 
-/**
- * Enables TypeBox schema validation
- *
- * @example
- * ```typescript
- * import Fastify from 'fastify'
- *
- * const server = Fastify().setValidatorCompiler(TypeBoxValidatorCompiler)
- * ```
- */
+import type {
+  Static,
+  TSchema,
+  SchemaOptions
+} from '@sinclair/typebox'
+
+import { TypeCompiler } from '@sinclair/typebox/compiler'
+import { TypeBuilder, Kind } from '@sinclair/typebox'
+
+// ----------------------------------------------------------------------------
+// FastifyTypeBuilder
+// ----------------------------------------------------------------------------
+
+export interface DateOptions extends SchemaOptions {}
+
+export interface TDate extends TSchema, DateOptions {
+  static: Date | string,
+  [Kind]: 'String',
+  type: 'string',
+  format: 'date'
+}
+
+export class FastifyTypeBuilder extends TypeBuilder {
+  /** Fastify Extension Type: Creates a Date type that infers as Date | string */
+  public Date (options: DateOptions = {}): TDate {
+    return super.Create({ ...options, [Kind]: 'String', type: 'string', format: 'date' })
+  }
+}
+
+export const Type = new FastifyTypeBuilder()
+
+// ----------------------------------------------------------------------------
+// TypeBoxValidatorCompiler
+// ----------------------------------------------------------------------------
+
+/** Enables TypeBox schema validation */
 export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schema }) => {
   const typeCheck = TypeCompiler.Compile(schema)
   return (value): any => {
@@ -38,6 +62,10 @@ export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schem
   }
 }
 
+// ----------------------------------------------------------------------------
+// TypeBoxTypeProvider
+// ----------------------------------------------------------------------------
+
 /**
  * Enables automatic type inference on a Fastify instance.
  *
@@ -51,6 +79,10 @@ export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schem
 export interface TypeBoxTypeProvider extends FastifyTypeProvider {
   output: this['input'] extends TSchema ? Static<this['input']> : never
 }
+
+// ----------------------------------------------------------------------------
+// FastifyPluginCallback
+// ----------------------------------------------------------------------------
 
 /**
  * FastifyPluginCallback with Typebox automatic type inference
@@ -69,6 +101,10 @@ export type FastifyPluginCallbackTypebox<
     Server extends RawServerBase = RawServerDefault,
 > = FastifyPluginCallback<Options, Server, TypeBoxTypeProvider>
 
+// ----------------------------------------------------------------------------
+// FastifyPluginAsyncTypebox
+// ----------------------------------------------------------------------------
+
 /**
  * FastifyPluginAsync with Typebox automatic type inference
  *
@@ -84,3 +120,83 @@ export type FastifyPluginAsyncTypebox<
   Options extends FastifyPluginOptions = Record<never, never>,
   Server extends RawServerBase = RawServerDefault
 > = FastifyPluginAsync<Options, Server, TypeBoxTypeProvider>
+
+// ----------------------------------------------------------------------------
+// TypeBox Infrastructure
+// ----------------------------------------------------------------------------
+
+export type {
+  ArrayOptions,
+  IntersectEvaluate,
+  IntersectReduce,
+  NumericOptions,
+  ObjectOptions,
+  ObjectProperties,
+  ObjectPropertyKeys,
+  OptionalPropertyKeys,
+  PropertiesReduce,
+  ReadonlyOptionalPropertyKeys,
+  ReadonlyPropertyKeys,
+  RequiredPropertyKeys,
+  SchemaOptions,
+  Static,
+  StaticContructorParameters,
+  StaticFunctionParameters,
+  StringFormatOption,
+  StringOptions,
+  TAny,
+  TAnySchema,
+  TArray,
+  TBoolean,
+  TConstructor,
+  TConstructorParameters,
+  TEnum,
+  TEnumOption,
+  TFunction,
+  TInstanceType,
+  TInteger,
+  TIntersect,
+  TKeyOf,
+  TLiteral,
+  TLiteralValue,
+  TModifier,
+  TNull,
+  TNumber,
+  TNumeric,
+  TObject,
+  TOmit,
+  TOptional,
+  TParameters,
+  TPartial,
+  TPick,
+  TPromise,
+  TProperties,
+  TReadonly,
+  TReadonlyOptional,
+  TRecord,
+  TRecordKey,
+  TRecordProperties,
+  TRecursive,
+  TRecursiveReduce,
+  TRef,
+  TRequired,
+  TReturnType,
+  TSchema,
+  TSelf,
+  TString,
+  TTuple,
+  TUint8Array,
+  TUndefined,
+  TUnion,
+  TUnknown,
+  TUnsafe,
+  TVoid,
+  TupleToArray,
+  TypeBuilder,
+  Uint8ArrayOptions,
+  UnionLast,
+  UnionStringLiteralToTuple,
+  UnionToIntersect,
+  UnionToTuple,
+  UnsafeOptions
+} from '@sinclair/typebox'

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,6 @@
 const tap = require('tap')
 const Fastify = require('fastify')
-const { Type } = require('@sinclair/typebox')
-const { TypeBoxValidatorCompiler } = require('../dist/index')
+const { Type, TypeBoxValidatorCompiler } = require('../dist/index')
 
 // This test ensures AJV ignores the TypeBox [Kind] symbol property in strict
 tap.test('should compile typebox schema without configuration', async t => {
@@ -86,4 +85,21 @@ tap.test('should return validation error message on response', async t => {
   }, (req, res) => res.send(req.query))
   const response = await fastify.inject().get('/').query({ a: '1', b: '2' }).then(res => res.json())
   t.equal(response.message.indexOf('querystring/c'), 0)
+})
+
+tap.test('should accept date extension type and refine correctly in handler', async t => {
+  t.plan(1)
+  let created = null
+  const fastify = Fastify().post('/', {
+    schema: {
+      body: Type.Object({
+        created: Type.Date()
+      })
+    }
+  }, (req, res) => {
+    created = req.body.created
+    res.json(0)
+  })
+  await fastify.inject().post('/').body({ created: '2022-01-01' }).then(res => res.json())
+  t.equal(typeof created, 'string') // note: not refined to Date
 })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,23 +1,24 @@
-import { TypeBoxTypeProvider } from '../index'
-import { Type } from '@sinclair/typebox'
+import { Type, TypeBoxTypeProvider } from '../index'
 import { expectAssignable, expectType } from 'tsd'
-import Fastify, { FastifyInstance, FastifyLoggerInstance, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerDefault } from 'fastify'
+import Fastify, { FastifyInstance, FastifyBaseLogger, RawReplyDefaultExpression, RawRequestDefaultExpression, RawServerDefault } from 'fastify'
 
 const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
-expectAssignable<FastifyInstance<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, FastifyLoggerInstance, TypeBoxTypeProvider>>(fastify)
+expectAssignable<FastifyInstance<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, FastifyBaseLogger, TypeBoxTypeProvider>>(fastify)
 
 fastify.get('/', {
   schema: {
     body: Type.Object({
       x: Type.String(),
       y: Type.Number(),
-      z: Type.Boolean()
+      z: Type.Boolean(),
+      w: Type.Date()
     })
   }
 }, (req) => {
   expectType<boolean>(req.body.z)
   expectType<number>(req.body.y)
   expectType<string>(req.body.x)
+  expectType<Date | string>(req.body.w)
 })
 
 expectAssignable<FastifyInstance>(Fastify())

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,8 +1,7 @@
-import { FastifyPluginAsyncTypebox, FastifyPluginCallbackTypebox } from '../index'
+import { Type, FastifyPluginAsyncTypebox, FastifyPluginCallbackTypebox } from '../index'
 import { expectType } from 'tsd'
 import Fastify, { FastifyPluginAsync, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
-import { Type } from '@sinclair/typebox'
 import { Http2Server } from 'http2'
 
 // Ensure the defaults of FastifyPluginAsyncTypebox are the same as FastifyPluginAsync


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


This PR exports the `Type.*` namespace on this Type Provider and provides a `Type.Date()` extension type by way of a custom `FastifyTypeBuilder` implementation. The aim of this PR is to provide a mechanism for additional extension types to be added for custom Ajv schema/value refinement (as configured in Fastify), as well as to streamline the developer experience by only requiring a single import to bring in both TypeProvider and Type infrastructure.

Note: While this PR only implements the `Type.Date()` extension type, other types can be added if necessary (with some consideration given to `Type.StringEnum(..)`, `Type.Nullable(...)` and other Open API schema representations that are not provided by TypeBox) 

#### Current
```typescript
import { Type } from '@sinclair/typebox'
import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox'
```
#### Proposed
```typescript
import { Type, Static, TypeBoxTypeProvider } from '@fastify/type-provider-typebox'

// ----------------------------------------------------
// Extension Type: Type.Date()
// ----------------------------------------------------

const T = Type.Date()     // const T = { type: 'string', format: 'Date' }

type T = Static<typeof T> // type T = Date | string
```
The exporting the `Type.*` namespace on this provider was discussed https://github.com/fastify/fastify-type-provider-typebox/issues/29.

Submitting for consideration