### PR TITLE
Update ReadMe code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import {
 } from 'fastify';
 import { Type } from '@sinclair/typebox';
 import { RouteGenericInterface } from 'fastify/types/route';
-import { FastifySchema } from "fastify/types/schema";
+import { FastifySchema } from 'fastify/types/schema';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
 export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyRequest<

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import { Type } from '@sinclair/typebox';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
-export type FastifyRequestTypebox<TSchema> = FastifyRequest<
+export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyRequest<
   RouteGenericInterface,
   RawServerDefault,
   RawRequestDefaultExpression<RawServerDefault>,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ import {
 } from 'fastify';
 import { Type } from '@sinclair/typebox';
 import { RouteGenericInterface } from 'fastify/types/route';
+import { FastifySchema } from "fastify/types/schema";
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
 
 export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyRequest<


### PR DESCRIPTION
The definition of `FastifyRequest` requires the `SchemaCompiler` (in this case the type-parameter `TSchema`) to extend `FastifySchema`.

This pull-request updates the readme to reflect this.