### PR TITLE
docs: add `FastifyReplyTypebox` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,15 @@ fastify.get('/', {
 })
 ```
 
-## Type definition of FastifyRequest + TypeProvider
+## Type definition of FastifyRequest & FastifyReply + TypeProvider
 ```ts
 import {
   FastifyReply,
   FastifyRequest,
   RawRequestDefaultExpression,
   RawServerDefault,
+  RawReplyDefaultExpression,
+  ContextConfigDefault
 } from 'fastify';
 import { RouteGenericInterface } from 'fastify/types/route';
 import { FastifySchema } from 'fastify/types/schema';
@@ -74,18 +76,38 @@ export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyReques
   TypeBoxTypeProvider
 >;
 
+export type FastifyReplyTypebox<TSchema extends FastifySchema> = FastifyReply<
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  RouteGenericInterface,
+  ContextConfigDefault,
+  TSchema,
+  TypeBoxTypeProvider
+>
+
 export const CreateProductSchema = {
   body: Type.Object({
     name: Type.String(),
     price: Type.Number(),
   }),
+  response: {
+    201: Type.Object({
+      id: Type.Number(),
+    }),
+  },
 };
 
 export const CreateProductHandler = (
-  req: FastifyRequestTypebox<typeof CreateProductSchema>
+  req: FastifyRequestTypebox<typeof CreateProductSchema>,
+  reply: FastifyReplyTypebox<typeof CreateProductSchema>
 ) => {
   // The `name` and `price` types are automatically inferred
   const { name, price } = req.body;
+
+  // The response body type is automatically inferred
+  reply.status(201).send({ id: 'string-value' });
+  //                       ^? error TS2322: Type 'string' is not assignable to type 'number'.
 };
 ```
 


### PR DESCRIPTION
#### Info
This PR adds a type definiton of `FastifyReplyTypebox` to the README. I think it's a good addition for users wondering how to get fully type-safe custom handlers.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
