### PR TITLE
Add `FastifyRouteHandlerTypebox` type and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,39 +54,14 @@ fastify.get('/', {
 })
 ```
 
-## Type definition of FastifyRequest & FastifyReply + TypeProvider
+## Type definition of RouteHandlerMethod
+
+When defining a route handler function that is defined outside of a route declaration, the function type must be set in order to get proper automatic type inference for request / reply.
+
 ```ts
-import {
-  FastifyReply,
-  FastifyRequest,
-  RawRequestDefaultExpression,
-  RawServerDefault,
-  RawReplyDefaultExpression,
-  ContextConfigDefault
-} from 'fastify';
-import { RouteGenericInterface } from 'fastify/types/route';
-import { FastifySchema } from 'fastify/types/schema';
-import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { Type, TypeBoxTypeProvider, FastifyRouteHandlerTypebox } from '@fastify/type-provider-typebox'
 
-export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyRequest<
-  RouteGenericInterface,
-  RawServerDefault,
-  RawRequestDefaultExpression<RawServerDefault>,
-  TSchema,
-  TypeBoxTypeProvider
->;
-
-export type FastifyReplyTypebox<TSchema extends FastifySchema> = FastifyReply<
-  RawServerDefault,
-  RawRequestDefaultExpression,
-  RawReplyDefaultExpression,
-  RouteGenericInterface,
-  ContextConfigDefault,
-  TSchema,
-  TypeBoxTypeProvider
->
-
-export const CreateProductSchema = {
+export const createProductSchema = {
   body: Type.Object({
     name: Type.String(),
     price: Type.Number(),
@@ -98,9 +73,9 @@ export const CreateProductSchema = {
   },
 };
 
-export const CreateProductHandler = (
-  req: FastifyRequestTypebox<typeof CreateProductSchema>,
-  reply: FastifyReplyTypebox<typeof CreateProductSchema>
+export const createProductHandler: FastifyRouteHandlerTypebox<typeof createProductSchema> = (
+  req,
+  reply
 ) => {
   // The `name` and `price` types are automatically inferred
   const { name, price } = req.body;
@@ -110,7 +85,6 @@ export const CreateProductHandler = (
   //                       ^? error TS2322: Type 'string' is not assignable to type 'number'.
 };
 ```
-
 
 ## Plugin definition
 

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,17 @@
 import {
+  ContextConfigDefault,
   FastifyPluginAsync,
   FastifyPluginCallback,
   FastifyPluginOptions,
+  FastifySchema,
   FastifySchemaCompiler,
   FastifyTypeProvider,
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
   RawServerBase,
-  RawServerDefault
+  RawServerDefault,
+  RouteGenericInterface,
+  RouteHandlerMethod
 } from 'fastify'
 import { TypeCompiler } from '@sinclair/typebox/compiler'
 import { Static, TSchema } from '@sinclair/typebox'
@@ -62,7 +68,7 @@ export interface TypeBoxTypeProvider extends FastifyTypeProvider {
  *
  * @example
  * ```typescript
- * import { FastifyPluginCallbackTypebox } fromg "@fastify/type-provider-typebox"
+ * import { FastifyPluginCallbackTypebox } from "@fastify/type-provider-typebox"
  *
  * const plugin: FastifyPluginCallbackTypebox = (fastify, options, done) => {
  *   done()
@@ -79,7 +85,7 @@ export type FastifyPluginCallbackTypebox<
  *
  * @example
  * ```typescript
- * import { FastifyPluginAsyncTypebox } fromg "@fastify/type-provider-typebox"
+ * import { FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox"
  *
  * const plugin: FastifyPluginAsyncTypebox = async (fastify, options) => {
  * }
@@ -89,3 +95,26 @@ export type FastifyPluginAsyncTypebox<
   Options extends FastifyPluginOptions = Record<never, never>,
   Server extends RawServerBase = RawServerDefault
 > = FastifyPluginAsync<Options, Server, TypeBoxTypeProvider>
+
+/**
+ * Fastify RouteHandlerMethod with Typebox automatic type inference for request / reply
+ *
+ * @example
+ * ```typescript
+ * import { FastifyRouteHandlerTypebox } from "@fastify/type-provider-typebox"
+ *
+ * const getHandler: FastifyRouteHandlerTypebox<myGetSchema> = async (req, reply) => {
+ * }
+ *
+ * fastify.get('/stuff', { schema: myGetSchema }, getHandler)
+ * ```
+ */
+export type FastifyRouteHandlerTypebox<TSchema extends FastifySchema> = RouteHandlerMethod<
+  RawServerDefault,
+  RawRequestDefaultExpression<RawServerDefault>,
+  RawReplyDefaultExpression<RawServerDefault>,
+  RouteGenericInterface,
+  ContextConfigDefault,
+  TSchema,
+  TypeBoxTypeProvider
+>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Description

Piggybacking on the existing `FastifyRequestTypebox` and `FastifyReplyTypebox` in the docs, this PR adds a `FastifyRouteHandlerTypebox` that will automatically infer the request and reply types for any non-inline route handler.

Instead of just documenting the type, this PR exports the new type directly to make this process as easy and painless for users - as the typescript needed to override the TypeProvider on Fastify types can be pretty confusing for new users.

I've removed the documentation for `FastifyRequestTypebox` and `FastifyReplyTypebox` since they are no longer needed if the handler function type is set, but we can keep them (or add them as exports as well) if that's something we want/need.

Proof this works:

![image](https://user-images.githubusercontent.com/2258445/233700952-043686c6-5512-49e6-9297-8ca9378767fc.png)


Thanks!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
