### PR TITLE
fix: example in README, replace GET method with POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { Type } from '@sinclair/typebox'
 
 const fastify = Fastify().withTypeProvider<TypeBoxTypeProvider>()
 
-fastify.get('/', {
+fastify.post('/', {
   schema: {
     body: Type.Object({
       x: Type.String(),


### PR DESCRIPTION
I’m trying to follow the README and the example throws an error for me:

> [FST_ERR_ROUTE_BODY_VALIDATION_SCHEMA_NOT_SUPPORTED](https://github.com/fastify/fastify/blob/main/docs/Reference/Errors.md#fst_err_route_body_validation_schema_not_supported)

I think that has to be changed to something like POST. Wdyt?

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
