### PR TITLE
ci: exlude node 14 and 16 for macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           exclude:
             - os: windows-latest
               node-version: 14
+            - os: macos-latest
+              node-version: 14
+            - os: macos-latest
+              node-version: 16
       steps:
         - name: Check out repo
           uses: actions/checkout@v4


### PR DESCRIPTION
Addresses issues with CI found in https://github.com/fastify/fastify-type-provider-typebox/pull/162#issuecomment-2285494022

Excludes MacOS CI from running on Node versions 14 and 16.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
