### PR TITLE
ci: revert to using custom CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,97 @@ on:
       - 'docs/**'
       - '*.md'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
+  dependency-review:
+      name: Dependency Review
+      if: github.event_name == 'pull_request'
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+      steps:
+          - name: Check out repo
+            uses: actions/checkout@v4
+            with:
+              persist-credentials: false
+
+          - name: Dependency review
+            uses: actions/dependency-review-action@v3
+
+  variants:
+      name: Read test variants
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+      outputs:
+        variants: ${{ steps.read-variants.outputs.variants }}
+      steps:
+        - name: Check out repo
+          uses: actions/checkout@v4
+          with:
+            persist-credentials: false
+        - name: Read variants
+          id: read-variants
+          run: |
+            echo "variants=$(cat ./test-variants.json)" >> "$GITHUB_OUTPUT"
+
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.1
-    with:
-      lint: true
-      license-check: true
+      needs: variants
+      name: Test
+      runs-on: ${{ matrix.os }}
+      permissions:
+        contents: read
+      strategy:
+        matrix:
+          node-version: [20, 22]
+          peer-version: ${{ fromJSON(needs.variants.outputs.variants) }}
+          os: [macos-latest, ubuntu-latest, windows-latest]
+          exclude:
+            - os: windows-latest
+              node-version: 14
+            - os: macos-latest
+              node-version: 14
+            - os: macos-latest
+              node-version: 16
+      steps:
+        - name: Check out repo
+          uses: actions/checkout@v4
+          with:
+            persist-credentials: false
+
+        - name: Setup Node ${{ matrix.node-version }}
+          uses: actions/setup-node@v4
+          with:
+            node-version: ${{ matrix.node-version }}
+
+        - name: Install dependencies
+          run: npm i --ignore-scripts
+
+        - name: Install peerdeps
+          run: npm i fastify @sinclair/typebox@${{ matrix.peer-version }}
+
+        - name: Lint code
+          if: ${{ matrix.node-version != 14 }}
+          run: npm run lint
+
+        - name: Run tests
+          run: npm test
+
+  automerge:
+    name: Automatically merge Dependabot pull requests
+    if: >
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       }
     }
   },
+  "peerDependencies": {
+    "@sinclair/typebox": ">=0.26 <=0.32"
+  },
   "scripts": {
     "build:clean": "rimraf ./dist",
     "build:cjs": "tsc --outDir dist/cjs --module CommonJS --moduleResolution Node10 --sourcemap false",
@@ -48,7 +51,6 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
     "@fastify/pre-commit": "^2.1.0",
-    "@sinclair/typebox": "^0.32.32",
     "@tapjs/tsx": "^1.1.32",
     "@types/node": "^20.14.2",
     "@typescript-eslint/eslint-plugin": "^7.13.0",


### PR DESCRIPTION
I overlooked the custom parts of the workflow and replaced it with the generic one, however to be able to test with individual typebox versions, we must keep the custom CI of the `v4` branch