### PR TITLE
docs(readme): correct TypeBox types in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,35 +63,46 @@ fastify.post('/', {
 
 ## Type definition of FastifyRequest & FastifyReply + TypeProvider
 ```ts
-import {
+import type { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import { Type } from '@fastify/type-provider-typebox';
+import type {
+  ContextConfigDefault,
+  FastifyBaseLogger,
+  FastifyInstance,
   FastifyReply,
   FastifyRequest,
+  RawReplyDefaultExpression,
   RawRequestDefaultExpression,
   RawServerDefault,
-  RawReplyDefaultExpression,
-  ContextConfigDefault
 } from 'fastify';
-import { RouteGenericInterface } from 'fastify/types/route';
-import { FastifySchema } from 'fastify/types/schema';
-import { Type, TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import type { RouteGenericInterface } from 'fastify/types/route';
+import type { FastifySchema } from 'fastify/types/schema';
 
-export type FastifyRequestTypebox<TSchema extends FastifySchema> = FastifyRequest<
+export type FastifyTypeBox = FastifyInstance<
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  FastifyBaseLogger,
+  TypeBoxTypeProvider
+>;
+
+export type FastifyRequestTypeBox<TSchema extends FastifySchema> = FastifyRequest<
   RouteGenericInterface,
   RawServerDefault,
-  RawRequestDefaultExpression<RawServerDefault>,
+  RawRequestDefaultExpression,
   TSchema,
   TypeBoxTypeProvider
 >;
 
-export type FastifyReplyTypebox<TSchema extends FastifySchema> = FastifyReply<
+export type FastifyReplyTypeBox<TSchema extends FastifySchema> = FastifyReply<
+  RouteGenericInterface,
   RawServerDefault,
   RawRequestDefaultExpression,
   RawReplyDefaultExpression,
-  RouteGenericInterface,
   ContextConfigDefault,
   TSchema,
   TypeBoxTypeProvider
->
+>;
 
 export const CreateProductSchema = {
   body: Type.Object({
@@ -106,8 +117,8 @@ export const CreateProductSchema = {
 };
 
 export const CreateProductHandler = (
-  req: FastifyRequestTypebox<typeof CreateProductSchema>,
-  reply: FastifyReplyTypebox<typeof CreateProductSchema>
+  req: FastifyRequestTypeBox<typeof CreateProductSchema>,
+  reply: FastifyReplyTypeBox<typeof CreateProductSchema>,
 ) => {
   // The `name` and `price` types are automatically inferred
   const { name, price } = req.body;


### PR DESCRIPTION
- Fixed `FastifyReplyTypebox` that had the incorrect order of generic types
- Added `FastifyTypeBox` as the Fastify instance with TypeBox as the type provider
- Renamed `...Typebox` -> `...TypeBox` (the lib's casing)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

-  N/A run `npm run test` and `npm run benchmark`
-  N/A tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
