### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/plugin.test-d.mts
+++ b/types/plugin.test-d.mts
@@ -2,7 +2,7 @@ import { Type, FastifyPluginAsyncTypebox, FastifyPluginCallbackTypebox } from '.
 import { expectType } from 'tsd'
 import Fastify, { FastifyPluginAsync, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
-import { Http2Server } from 'http2'
+import { Http2Server } from 'node:http2'
 
 // Ensure the defaults of FastifyPluginAsyncTypebox are the same as FastifyPluginAsync
 export const pluginAsyncDefaults: FastifyPluginAsync = async (fastify, options) => {


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.