### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@tapjs/tsx": "^3.0.0",
     "@types/node": "^22.7.6",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "fastify-plugin": "^5.0.0",
     "fastify-tsconfig": "^2.0.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.