### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
       name: Dependency Review


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174