### PR TITLE
perf: remove intermediate list creation when constructing the error list

### DIFF
--- a/index.mts
+++ b/index.mts
@@ -31,16 +31,18 @@ export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schem
     }
     const errors = []
     for (const error of typeCheck.Errors(converted)) {
+      errors.push({
+        message: error.message,
+        instancePath: error.path
+      })
+    }
+    return {
       // Note: Here we return a FastifySchemaValidationError[] result. As of writing, Fastify
       // does not currently export this type. Future revisions should uncomment the assertion
       // below and return the full set of properties. The specified properties 'message' and
       // 'instancePath' do however result in a near equivalent error messages to Ajv.
-      errors.push({
-        message: error.message,
-        instancePath: error.path
-      }) // as FastifySchemaValidationError[]
+      error: errors // as FastifySchemaValidationError[]
     }
-    return { error: errors }
   }
 }
 

--- a/index.mts
+++ b/index.mts
@@ -29,17 +29,18 @@ export const TypeBoxValidatorCompiler: FastifySchemaCompiler<TSchema> = ({ schem
     if (typeCheck.Check(converted)) {
       return { value: converted }
     }
-    const errors = [...typeCheck.Errors(converted)]
-    return {
+    const errors = []
+    for (const error of typeCheck.Errors(converted)) {
       // Note: Here we return a FastifySchemaValidationError[] result. As of writing, Fastify
       // does not currently export this type. Future revisions should uncomment the assertion
       // below and return the full set of properties. The specified properties 'message' and
       // 'instancePath' do however result in a near equivalent error messages to Ajv.
-      error: errors.map((error) => ({
-        message: `${error.message}`,
+      errors.push({
+        message: error.message,
         instancePath: error.path
-      })) // as FastifySchemaValidationError[]
+      }) // as FastifySchemaValidationError[]
     }
+    return { error: errors }
   }
 }
 


### PR DESCRIPTION
Removes the usage of an intermediate list and `.map` when creating the error list, which should make it faster

I created a small benchmark with Claude and it does indeed seem faster (node 22.17):

```sh
Verifying results are equivalent...
Old result errors: 5
New result errors: 5
Results match: true

Running 100,000 iterations each...

Old approach (spread + map):
  Total time: 244.55ms
  Average per operation: 0.0024ms
  Operations per second: 408,913

New approach (for loop + push):
  Total time: 214.47ms
  Average per operation: 0.0021ms
  Operations per second: 466,262
```

Benchmark:

```ts
import { TypeCompiler } from '@sinclair/typebox/compiler'
import { Type } from '@sinclair/typebox'
import { Value } from '@sinclair/typebox/value'

const schema = Type.Object({
  name: Type.String({ minLength: 3 }),
  age: Type.Number({ minimum: 0, maximum: 120 }),
  email: Type.String({ format: 'email' }),
  address: Type.Object({
    street: Type.String(),
    city: Type.String(),
    zipCode: Type.String({ pattern: '^[0-9]{5}$' })
  })
})

// Invalid data that will trigger multiple validation errors
const invalidData = {
  name: 'ab', // too short
  age: -5, // negative
  email: 'invalid-email', // invalid format
  address: {
    street: '', // empty
    city: 123, // wrong type
    zipCode: 'invalid' // wrong pattern
  }
}

const typeCheck = TypeCompiler.Compile(schema)

// Old approach (using spread and map)
function oldErrorConstruction () {
  const errors = [...typeCheck.Errors(invalidData)]
  return {
    error: errors.map((error) => ({
      message: `${error.message}`,
      instancePath: error.path
    }))
  }
}

// New approach (using for loop and push)
function newErrorConstruction () {
  const errors = []
  for (const error of typeCheck.Errors(invalidData)) {
    errors.push({
      message: error.message,
      instancePath: error.path
    })
  }
  return { error: errors }
}

// Benchmark function
function benchmark (name, fn, iterations = 100000) {
  // Warm up
  for (let i = 0; i < 1000; i++) {
    fn()
  }
  
  const start = process.hrtime.bigint()
  for (let i = 0; i < iterations; i++) {
    fn()
  }
  const end = process.hrtime.bigint()
  
  const duration = Number(end - start) / 1000000 // Convert to milliseconds
  const opsPerSecond = Math.round(iterations / (duration / 1000))
  
  console.log(`${name}:`)
  console.log(`  Total time: ${duration.toFixed(2)}ms`)
  console.log(`  Average per operation: ${(duration / iterations).toFixed(4)}ms`)
  console.log(`  Operations per second: ${opsPerSecond.toLocaleString()}`)
  console.log()
  
  return duration
}

console.log('TypeBox Error Construction Benchmark')
console.log('====================================')
console.log()

// Verify both functions produce the same result
const oldResult = oldErrorConstruction()
const newResult = newErrorConstruction()

console.log('Verifying results are equivalent...')
console.log('Old result errors:', oldResult.error.length)
console.log('New result errors:', newResult.error.length)
console.log('Results match:', JSON.stringify(oldResult) === JSON.stringify(newResult))
console.log()

// Run benchmarks
const iterations = 100000
console.log(`Running ${iterations.toLocaleString()} iterations each...`)
console.log()

const oldTime = benchmark('Old approach (spread + map)', oldErrorConstruction, iterations)
const newTime = benchmark('New approach (for loop + push)', newErrorConstruction, iterations)

// Calculate improvement
const improvement = ((oldTime - newTime) / oldTime) * 100
console.log('Performance Summary:')
console.log('===================')
if (improvement > 0) {
  console.log(`New approach is ${improvement.toFixed(1)}% faster`)
} else {
  console.log(`Old approach is ${Math.abs(improvement).toFixed(1)}% faster`)
}
console.log(`Speed ratio: ${(oldTime / newTime).toFixed(2)}x`)
```