### PR TITLE
feat: export Format from Typebox

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ fastify.withTypeProvider<TypeBoxTypeProvider>().get('/', {
 
 For additional information on this compiler, please refer to the TypeBox documentation located [here](https://github.com/sinclairzx81/typebox#Compile).
 
+## Register formats
+
+The Format module of TypeBox can be used to register string formats.
+
+```ts
+import { Format } from '@fastify/type-provider-typebox'
+
+Format.Set('custom-format', (value) => value === 'custom');
+Format.Set('regex-format', (value) => /^my-format$/.test(value));
+```
+
+See the [official TypeBox documentation](https://sinclairzx81.github.io/typebox/#/docs/format/overview) for additional information on formats.
+
 ## License
 
 Licensed under [MIT](./LICENSE).

--- a/index.mts
+++ b/index.mts
@@ -12,6 +12,7 @@ import { Compile } from 'typebox/compile'
 import { type Static, type TSchema } from 'typebox'
 import { Value } from 'typebox/value'
 export * from 'typebox'
+export { default as Format } from 'typebox/format'
 /**
  * Enables TypeBox schema validation
  *


### PR DESCRIPTION
### Description

The lib now exports the `Format` variable from `typebox/format`.
Previously it was `FormatRegistry` but it's no longer available since Typebox v1 upgrade.
`Format` can be used to register formats on the Typebox instance used by the Fastify plugin.
I've added some documentation about the `Format` module in the Readme.

### Issue

Closes https://github.com/fastify/fastify-type-provider-typebox/issues/251

### Checklist

- [X] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
  - *To me the change I made does not need new tests but tell me if it does*
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
